### PR TITLE
Fix/listener-any

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Andreas Hubert
+Copyright (c) 2024 Andreas Hubert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ansible Role: PostgreSQL
 
 [![CI](https://github.com/ahu-services/ansible-role-postgresql/workflows/CI/badge.svg?event=push)](https://github.com/ahu-services/ansible-role-postgresql/actions?query=workflow%3ACI)
 
-Installs and configures PostgtreSQL Server 15 on RockyLinux servers.
+Installs and configures PostgtreSQL Server 14-16 on RockyLinux servers.
 
 Role Variables
 --------------

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -56,3 +56,13 @@
       ansible.builtin.assert:
         that:
           - postgres_info.version.full == "{{ psql_version }}"
+    - name: Check content of the configuration file
+      ansible.builtin.slurp:
+        src: /var/lib/pgsql/{{ psql_version_major }}/data/postgresql.conf
+      register: pgsql_conf
+    - name: Assert file content
+      ansible.builtin.assert:
+        that:
+          - "\"listen_addresses = '*'\" in (pgsql_conf['content'] | b64decode)"
+        fail_msg: "'listen_addresses = '*' setting is missing in postgresql.conf"
+        success_msg: "'listen_addresses = '*' setting is present in postgresql.conf"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,3 +9,12 @@
   become: true
   notify: Restart postgresql
   when: postgresql_hba_entries | length > 0
+- name: Configure listener to any interface
+  become: true
+  become_user: postgres
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_config_path }}/postgresql.conf"
+    regexp: '^listen_addresses ='
+    insertbefore: '^#listen_addresses'
+    line: "listen_addresses = '*'"
+  notify: Restart postgresql


### PR DESCRIPTION
Configuration for listener_addresses was missing. New default is now listening on '*', which means any.