### PR TITLE
Fix galaxy namespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on: # yamllint disable-line rule:truthy
 
 defaults:
   run:
-    working-directory: 'ahu.postgresql'
+    working-directory: 'ahu_services.postgresql'
 
 jobs:
   release:
@@ -25,7 +25,7 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v2
         with:
-          path: 'ahu.postgresql'
+          path: 'ahu_services.postgresql'
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2023 Andreas Hubert
+Copyright (c) 2024 Andreas Hubert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Including an example of how to use your role (for instance, with variables passe
       tasks:
         - name: Setup PostgreSQL Server
           ansible.builtin.include_role:
-            name: "ahu.postgresql"
+            name: "ahu_services.postgresql"
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ansible Role: PostgreSQL
 
 [![CI](https://github.com/ahu-services/ansible-role-postgresql/workflows/CI/badge.svg?event=push)](https://github.com/ahu-services/ansible-role-postgresql/actions?query=workflow%3ACI)
 
-Installs and configures PostgtreSQL Server 15 on RockyLinux servers.
+Installs and configures PostgtreSQL Server 14-16 on RockyLinux servers.
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   role_name: postgresql
   author: Andreas Hubert
-  namespace: ahu
+  namespace: ahu_services
   description: PostgreSQL Server for Linux, using packages from postgresql.org
   company: Andreas Hubert
   license: MIT

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -18,6 +18,6 @@
       - {type: host, database: all, user: all, address: '::1/128', auth_method: "{{ postgresql_auth_method }}"}
       - {type: host, database: corpus, user: corpus, address: 0.0.0.0/0, auth_method: "{{ postgresql_auth_method }}"}
   tasks:
-    - name: Include ahu.postgresql
+    - name: Include ahu_services.postgresql
       ansible.builtin.include_role:
-        name: ahu.postgresql
+        name: ahu_services.postgresql

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -56,3 +56,13 @@
       ansible.builtin.assert:
         that:
           - postgres_info.version.full == "{{ psql_version }}"
+    - name: Check content of the configuration file
+      ansible.builtin.slurp:
+        src: /var/lib/pgsql/{{ psql_version_major }}/data/postgresql.conf
+      register: pgsql_conf
+    - name: Assert file content
+      ansible.builtin.assert:
+        that:
+          - "\"listen_addresses = '*'\" in (pgsql_conf['content'] | b64decode)"
+        fail_msg: "'listen_addresses = '*' setting is missing in postgresql.conf"
+        success_msg: "'listen_addresses = '*' setting is present in postgresql.conf"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,3 +9,12 @@
   become: true
   notify: Restart postgresql
   when: postgresql_hba_entries | length > 0
+- name: Configure listener to any interface
+  become: true
+  become_user: postgres
+  ansible.builtin.lineinfile:
+    path: "{{ postgresql_config_path }}/postgresql.conf"
+    regexp: '^listen_addresses ='
+    insertbefore: '^#listen_addresses'
+    line: "listen_addresses = '*'"
+  notify: Restart postgresql


### PR DESCRIPTION
Galaxy namespaces seem to be connected with GitHub account names. Since I am not owner of `ahu` I have to use `ahu_services`